### PR TITLE
add support for MATLAB table columns of type 'string'

### DIFF
--- a/t2df.m
+++ b/t2df.m
@@ -27,7 +27,7 @@ function df = t2df(tab)
             elseif contains(types{k}, 'int')
                 %pandasColumn = py.pandas.DataFrame(column(:,l), columns = {names{k}}, dtype=types{k});
                 pandasColumn = py.pandas.DataFrame(arrayfun(@(x) py.int(x), column(:,l), 'UniformOutput', false)', columns = {names{k}}, dtype=types{k});
-            elseif matches(types{k}, 'char')
+            elseif matches(types{k}, 'char') || matches(types{k}, 'string')
                 %pandasColumn = py.pandas.DataFrame(column(:,l), columns = {names{k}}, dtype="string");
                 pandasColumn = py.pandas.DataFrame(arrayfun(@(x) py.str(x), column(:,l), 'UniformOutput', false)', columns = {names{k}}, dtype="string");
             elseif matches(types{k}, 'double') || matches(types{k}, 'float')
@@ -35,7 +35,7 @@ function df = t2df(tab)
                   pandasColumn = py.pandas.DataFrame(arrayfun(@(x) py.float(x), column(:,l), 'UniformOutput', false)', columns = {names{k}}, dtype="float");
                 
             else
-                error("unknown type");
+                error("unknown type: " + string(types{k}));
             end
             df = py.pandas.concat({df, pandasColumn}, axis = 1);
         end


### PR DESCRIPTION
hi, good project!  This PR fixes a small oversight I discovered after running `test.mlx`.  I tried to do a circular test where I create a table with `df2t()` then convert the returned table back to a dataframe with `t2df()`.  This is what happened:
```
    >> t = df2t(df);
    >> t2df(t)
    Error using t2df
    unknown type
```

The fix does two things:
1. gives a more descriptive error; in this case the returned error would have been
`    unknown type:  string`
  instead of just
`    unknown type`
2. handles string type (after which the circular test works)
